### PR TITLE
通知するreviewを前日のものだけにする

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ func main() {
 	jst, _ := time.LoadLocation("Asia/Tokyo")
 	base := time.Now().In(jst).Add(-time.Hour * 24)
 	year, month, day := base.Date()
-	baseTime := time.Date(year, month, day, 0, 0, 0, 0, base.Location())
+	startTime := time.Date(year, month, day, 0, 0, 0, 0, base.Location())
+	endTime := startTime.Add(time.Hour * 24)
 
 	webhookUrl := os.Getenv("REVIEW_SLACK_WEBHOOK_URL")
 	for _, review := range result.Reviews {
@@ -42,7 +43,7 @@ func main() {
 
 		updatedAtInJST := updatedAt.In(jst)
 
-		if updatedAtInJST.Before(baseTime) || int(review.Rating) == 0 {
+		if updatedAtInJST.Before(startTime) || updatedAtInJST.After(endTime) || int(review.Rating) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
時間の後ろを切っていなかったので、実行日当日に書かれた review も通知されてしまっていた
前日に update されたもののみ通知するように修正